### PR TITLE
Multiplayer refactor and making Client connection easier to use 

### DIFF
--- a/Engine/AM2E/Networking/Client.cs
+++ b/Engine/AM2E/Networking/Client.cs
@@ -1,0 +1,156 @@
+using ENet;
+using static AM2E.Networking.NetworkManager;
+
+namespace AM2E.Networking;
+
+internal static class Client
+{
+    private static void ParseDataPacket(MemoryStream packetStream, int senderId)
+    {
+        var guidBytes = new byte[16];
+        try
+        {
+            packetStream.ReadExactly(guidBytes);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Error when reading data packet:\n{ex}");
+            return;
+        }
+
+        var guid = new Guid(guidBytes);
+        var data = new byte[packetStream.Length - packetStream.Position];
+        packetStream.ReadExactly(data);
+        HandleDataPacket(guid, data, senderId);
+    }
+
+    private static void ParseStaticDataPacket(MemoryStream packetStream, int senderId)
+    {
+        if (packetStream.Length - packetStream.Position < 4)
+        {
+            Logger.Warn($"Error when reading data packet: Packet is not long enough!");
+            return;
+        }
+        using var br = GetBinaryReader(packetStream);
+
+        var networkId = br.ReadInt32();
+        var data = new byte[packetStream.Length - packetStream.Position];
+        packetStream.ReadExactly(data);
+        HandleStaticDataPacket(networkId, data, senderId);
+    }
+
+    private static void ClientHandlePacket(Packet packet)
+    {
+        if (packet.Length == 0)
+        {
+            Logger.Warn("Received malformed packet");
+            return;
+        }
+
+        var bytes = new byte[packet.Length];
+        packet.CopyTo(bytes);
+
+        using var ms = new MemoryStream(bytes);
+        var packetType = (PacketTypes)ms.ReadByte();
+
+        switch (packetType)
+        {
+            case PacketTypes.Data:
+                {
+                    var senderId = ms.ReadByte();
+                    if (senderId == -1)
+                    {
+                        Logger.Warn($"Error: Malformed data packet");
+                    }
+
+                    var idType = (IdTypes)ms.ReadByte();
+                    switch (idType)
+                    {
+                        case IdTypes.Guid:
+                            ParseDataPacket(ms, senderId);
+                            break;
+                        case IdTypes.Static:
+                            ParseStaticDataPacket(ms, senderId);
+                            break;
+                        default:
+                            Logger.Warn($"Unexpected id type in packet body");
+                            break;
+                    }
+                    break;
+                }
+            case PacketTypes.Disconnect:
+                {
+                    var disconnectedPeerId = ms.ReadByte();
+                    if (disconnectedPeerId == -1)
+                    {
+                        Logger.Warn("Error: Malformed disconnect packet");
+                        return;
+                    }
+                    Logger.Debug($"Client disconnected with ID: {disconnectedPeerId}");
+                    OnPeerDisconnected(disconnectedPeerId);
+                    break;
+                }
+            case PacketTypes.Connect:
+                {
+                    var connectedPeerId = ms.ReadByte();
+                    if (connectedPeerId == -1)
+                    {
+                        Logger.Warn($"Error: Malformed connect packet");
+                        return;
+                    }
+                    OnPeerConnected(connectedPeerId);
+                    Logger.Debug($"Client connected with ID: {connectedPeerId}");
+                    break;
+                }
+            case PacketTypes.ConnectionEstablished:
+                {
+                    var remotePeerId = ms.ReadByte();
+                    if (remotePeerId == -1)
+                    {
+                        Logger.Warn($"Error: Malformed connection established packt");
+                        return;
+                    }
+                    Logger.Debug($"Finished connecting to server, remote peer id: {remotePeerId}");
+                    isConnected = true;
+                    RemotePeerId = remotePeerId;
+                    OnConnectedToServer(remotePeerId);
+                    break;
+                }
+            default:
+                {
+                    Logger.Warn($"Received unrecognised packet type");
+                    break;
+                }
+        }
+    }
+
+    internal static void ClientTick(Host host)
+    {
+        for (var result = host.Service(0, out var netEvent); result > 0; result = host.CheckEvents(out netEvent))
+        {
+            switch (netEvent.Type)
+            {
+                case EventType.Connect:
+                    connectedPeers.Add(netEvent.Peer.ID, netEvent.Peer);
+                    Logger.Debug($"Server acknowledged connection, waiting for full connection to be established");
+                    break;
+                case EventType.Disconnect:
+                    connectedPeers.Remove(netEvent.Peer.ID);
+                    Logger.Debug("Server disconnected");
+                    StopClient();
+                    return;
+                case EventType.Receive:
+                    {
+                        using var packet = netEvent.Packet;
+                        ClientHandlePacket(packet);
+                        break;
+                    }
+                case EventType.Timeout:
+                    connectedPeers.Remove(netEvent.Peer.ID);
+                    Logger.Debug("Server timed out");
+                    StopClient();
+                    return;
+            }
+        }	
+    }
+}

--- a/Engine/AM2E/Networking/Client.cs
+++ b/Engine/AM2E/Networking/Client.cs
@@ -1,5 +1,6 @@
 using ENet;
 using static AM2E.Networking.NetworkManager;
+using static AM2E.Networking.NetworkHelpers;
 
 namespace AM2E.Networking;
 

--- a/Engine/AM2E/Networking/Client.cs
+++ b/Engine/AM2E/Networking/Client.cs
@@ -6,6 +6,14 @@ namespace AM2E.Networking;
 
 internal static class Client
 {
+    internal static Action<bool> finishedAction = (_) => {};
+
+    private static void OnConnectionFinished(bool wasSuccessful)
+    {
+        finishedAction(wasSuccessful);
+        finishedAction = (_) => {};
+    }
+
     private static void ParseDataPacket(MemoryStream packetStream, int senderId)
     {
         var guidBytes = new byte[16];
@@ -115,6 +123,7 @@ internal static class Client
                     isConnected = true;
                     RemotePeerId = remotePeerId;
                     OnConnectedToServer(remotePeerId);
+                    OnConnectionFinished(true);
                     break;
                 }
             default:
@@ -138,6 +147,10 @@ internal static class Client
                 case EventType.Disconnect:
                     connectedPeers.Remove(netEvent.Peer.ID);
                     Logger.Debug("Server disconnected");
+                    if (!isConnected)
+                    {
+                        OnConnectionFinished(false);
+                    }
                     StopClient();
                     return;
                 case EventType.Receive:
@@ -149,6 +162,10 @@ internal static class Client
                 case EventType.Timeout:
                     connectedPeers.Remove(netEvent.Peer.ID);
                     Logger.Debug("Server timed out");
+                    if (!isConnected)
+                    {
+                        OnConnectionFinished(false);
+                    }
                     StopClient();
                     return;
             }

--- a/Engine/AM2E/Networking/NetworkHelpers.cs
+++ b/Engine/AM2E/Networking/NetworkHelpers.cs
@@ -1,0 +1,56 @@
+using System.Text;
+using ENet;
+
+namespace AM2E.Networking;
+
+internal static class NetworkHelpers
+{
+    internal enum PacketTypes
+    {
+        Data = 0,
+        Connect = 1,
+        Disconnect = 2,
+        ConnectionEstablished = 3
+    }
+
+    internal enum IdTypes
+    {
+        Guid = 0,
+        Static = 1
+    }
+
+    internal static PacketFlags ReliabilityToPacketFlags(PacketReliability reliability)
+    {
+        return reliability switch
+        {
+            PacketReliability.Reliable => PacketFlags.Reliable,
+            PacketReliability.UnreliableOrdered => PacketFlags.UnreliableFragmented,
+            PacketReliability.Unreliable => PacketFlags.UnreliableFragmented | PacketFlags.Unsequenced,
+            _ => throw new Exception("Invalid reliability value")
+        };
+    }
+
+    internal static Packet CreateENetPacket(byte[] data, PacketReliability reliability)
+    {
+        var packet = default(Packet);
+        packet.Create(data, ReliabilityToPacketFlags(reliability));
+        return packet;
+    }
+
+    // This would actually be a really good situation for strong typing
+    internal static byte GetENetChannelId(PacketReliability reliability, int channelId)
+    {
+        return (byte)(reliability + channelId * 3);        
+    }
+
+    // We don't want our streams closed randomly
+    internal static BinaryReader GetBinaryReader(Stream stream)
+    {
+        return new BinaryReader(stream, Encoding.UTF8, true);
+    }
+
+    internal static BinaryWriter GetBinaryWriter(Stream stream)
+    {
+        return new BinaryWriter(stream, Encoding.UTF8, true);
+    }
+}

--- a/Engine/AM2E/Networking/NetworkManager.cs
+++ b/Engine/AM2E/Networking/NetworkManager.cs
@@ -1,6 +1,6 @@
 ﻿using AM2E.Actors;
 using ENet;
-using System.Text;
+using static AM2E.Networking.NetworkHelpers;
 
 namespace AM2E.Networking;
 
@@ -47,27 +47,6 @@ public static class NetworkManager
     public static event Action? DisconnectedFromServer;
 
     const byte ServerPeerId = 0;
-
-    internal enum PacketTypes
-    {
-        Data = 0,
-        Connect = 1,
-        Disconnect = 2,
-        ConnectionEstablished = 3
-    }
-
-    internal enum IdTypes
-    {
-        Guid = 0,
-        Static = 1
-    }
-
-    public enum PacketReliability
-    {
-        Reliable = 0,
-        UnreliableOrdered = 1,
-        Unreliable = 2
-    }
 
     static Host? host;
 
@@ -233,17 +212,6 @@ public static class NetworkManager
         host!.Flush();
     }
 
-    // We don't want our streams closed randomly
-    internal static BinaryReader GetBinaryReader(Stream stream)
-    {
-        return new BinaryReader(stream, Encoding.UTF8, true);
-    }
-
-    internal static BinaryWriter GetBinaryWriter(Stream stream)
-    {
-        return new BinaryWriter(stream, Encoding.UTF8, true);
-    }
-
     internal static void RegisterStaticActor(int networkId, StaticNetworkedActor actor)
     {
         staticNetworkedActors.Add(networkId, actor);
@@ -260,13 +228,7 @@ public static class NetworkManager
         {
             throw new InvalidOperationException("Cannot kick players when not running an active server");
         }
-        if (connectedPeers.TryGetValue((uint)peerId, out var peer))
-        {
-            NotifyPeersOfDisconnection(peer);
-            peer.DisconnectNow(0);
-            connectedPeers.Remove((uint)peerId);
-            PeerDisconnected?.Invoke(peerId);
-        }
+        Server.KickPeer(peerId);
     }
 
     public static string GetPeerIP(int peerId)
@@ -370,44 +332,29 @@ public static class NetworkManager
         packetStream.Write(actorId.ToByteArray());
     }
 
-    internal static PacketFlags ReliabilityToPacketFlags(PacketReliability reliability)
-    {
-        return reliability switch
-        {
-            PacketReliability.Reliable => PacketFlags.Reliable,
-            PacketReliability.UnreliableOrdered => PacketFlags.UnreliableFragmented,
-            PacketReliability.Unreliable => PacketFlags.UnreliableFragmented | PacketFlags.Unsequenced,
-            _ => throw new Exception("Invalid reliability value")
-        };
-    }
-
     private static void ClientSendDataPacket(MemoryStream packetStream, byte[] data, PacketReliability reliability, int channelId)
     {
         packetStream.Write(data);
-        var packet = default(Packet);
-        var flags = ReliabilityToPacketFlags(reliability);
-        packet.Create(packetStream.ToArray(), flags);
-        var channel = reliability + channelId * 3;
-        host!.Broadcast((byte)channel, ref packet);
+        var packet = CreateENetPacket(packetStream.ToArray(), reliability);
+        var enetChannel = GetENetChannelId(reliability, channelId);
+        host!.Broadcast(enetChannel, ref packet);
     }
 
     private static void ServerSendDataPacket(MemoryStream packetStream, byte[] data, PacketReliability reliability, int channelId, List<int> targetPeers)
     {
         packetStream.Write(data);
-        var packet = default(Packet);
-        var flags = ReliabilityToPacketFlags(reliability);
-        packet.Create(packetStream.ToArray(), flags);
+        var packet = CreateENetPacket(packetStream.ToArray(), reliability);
 
-        var channel = reliability + channelId * 3;
+        var enetChannel = GetENetChannelId(reliability, channelId);
         
         if (targetPeers.Count > 0)
         {
             var peers = targetPeers.Select(x => connectedPeers.GetValueOrDefault((uint)x)).ToArray();
-            host!.Broadcast((byte)channel, ref packet, peers);
+            host!.Broadcast(enetChannel, ref packet, peers);
         }
         else
         {
-            host!.Broadcast((byte)channel, ref packet);
+            host!.Broadcast(enetChannel, ref packet);
         }
     }
 
@@ -441,15 +388,25 @@ public static class NetworkManager
         }
     }
 
+    internal static void DisconnectPeer(uint peerId)
+    {
+        if (IsServer && connectedPeers.TryGetValue(peerId, out var peer))
+        {
+            NotifyPeersOfDisconnection(peer);
+            OnPeerDisconnected((int)peerId);
+        }
+        connectedPeers.Remove(peerId);
+    }
+
     private static void NotifyPeersOfDisconnection(Peer peer)
     {
         var peerId = peer.ID + 1;
+        var defaultReliableChannel = GetENetChannelId(PacketReliability.Reliable, 0);
         var disconnectData = new byte[2];
         disconnectData[0] = (byte)PacketTypes.Disconnect;
         disconnectData[1] = (byte)peerId;
-        var disconnectPacket = default(Packet);
-        disconnectPacket.Create(disconnectData, PacketFlags.Reliable);
+        var disconnectPacket = CreateENetPacket(disconnectData, PacketReliability.Reliable);
 
-        host!.Broadcast(1, ref disconnectPacket);
+        host!.Broadcast(defaultReliableChannel, ref disconnectPacket);
     }
 }

--- a/Engine/AM2E/Networking/NetworkManager.cs
+++ b/Engine/AM2E/Networking/NetworkManager.cs
@@ -48,7 +48,7 @@ public static class NetworkManager
 
     const byte ServerPeerId = 0;
 
-    enum PacketTypes
+    internal enum PacketTypes
     {
         Data = 0,
         Connect = 1,
@@ -56,7 +56,7 @@ public static class NetworkManager
         ConnectionEstablished = 3
     }
 
-    enum IdTypes
+    internal enum IdTypes
     {
         Guid = 0,
         Static = 1
@@ -71,13 +71,23 @@ public static class NetworkManager
 
     static Host? host;
 
-    readonly static Dictionary<uint, Peer> connectedPeers = [];
+    internal readonly static Dictionary<uint, Peer> connectedPeers = [];
 
     readonly static Dictionary<int, StaticNetworkedActor> staticNetworkedActors = [];
 
     const int DEFAULT_MAX_CLIENTS = 32;
 
     const int NUM_CHANNELS = 5;
+
+    internal static void OnPeerConnected(int peerId)
+    {
+        PeerConnected?.Invoke(peerId);
+    }
+
+    internal static void OnPeerDisconnected(int peerId)
+    {
+        PeerDisconnected?.Invoke(peerId);
+    }
 
     public static void StartServer(int port, int maxClients = DEFAULT_MAX_CLIENTS)
     {
@@ -197,9 +207,10 @@ public static class NetworkManager
             return;
         }
 
+        // Host should be non-null when isNetworking is true
         if (isServer)
         {
-            ServerTick();
+            Server.ServerTick(host!);
         }
         else
         {
@@ -218,12 +229,12 @@ public static class NetworkManager
     }
 
     // We don't want our streams closed randomly
-    private static BinaryReader GetBinaryReader(Stream stream)
+    internal static BinaryReader GetBinaryReader(Stream stream)
     {
         return new BinaryReader(stream, Encoding.UTF8, true);
     }
 
-    private static BinaryWriter GetBinaryWriter(Stream stream)
+    internal static BinaryWriter GetBinaryWriter(Stream stream)
     {
         return new BinaryWriter(stream, Encoding.UTF8, true);
     }
@@ -354,7 +365,7 @@ public static class NetworkManager
         packetStream.Write(actorId.ToByteArray());
     }
 
-    private static PacketFlags ReliabilityToPacketFlags(PacketReliability reliability)
+    internal static PacketFlags ReliabilityToPacketFlags(PacketReliability reliability)
     {
         return reliability switch
         {
@@ -395,7 +406,7 @@ public static class NetworkManager
         }
     }
 
-    private static void HandleDataPacket(Guid id, byte[] data, int senderId)
+    internal static void HandleDataPacket(Guid id, byte[] data, int senderId)
     {
         var actor = Actor.GetActor(id.ToString());
         if (actor is null || !(actor.Level?.Active ?? true))
@@ -412,7 +423,7 @@ public static class NetworkManager
         }
     }
 
-    private static void HandleStaticDataPacket(int networkId, byte[] data, int senderId)
+    internal static void HandleStaticDataPacket(int networkId, byte[] data, int senderId)
     {
         var actor = staticNetworkedActors.GetValueOrDefault(networkId);
         if (actor is not null)
@@ -422,133 +433,6 @@ public static class NetworkManager
         else
         {
             Logger.Debug($"Received packet for id: {networkId} but there was no local actor for that id");
-        }
-    }
-
-    private static byte[] CreateRebroadcastData(byte[] data, int peerId)
-    {
-        using var ms = new MemoryStream();
-        ms.WriteByte((byte)PacketTypes.Data);
-        ms.WriteByte((byte)peerId);
-        ms.Write(data);
-
-        return ms.ToArray();
-    }
-
-    private static (List<Peer>?, bool) TryGetTargetPeers(Stream packetStream)
-    {
-        try
-        {
-            var peerCount = packetStream.ReadByte();
-            var packetIsForServer = false;
-            var peers = new List<Peer>();
-            for (var i = 0; i < peerCount; i++)
-            {
-                var peer = packetStream.ReadByte();
-                if (peer == ServerPeerId)
-                {
-                    packetIsForServer = true;
-                }
-                else
-                {
-                    peers.Add(connectedPeers.GetValueOrDefault((uint)peer));
-                }
-            }
-            return (peers, packetIsForServer);
-        }
-        catch (Exception ex)
-        {
-            Logger.Warn($"Error when parsing packet header:\n{ex}");
-            return (null, false);
-        }
-    }
-
-    private static void ServerHandleGuidPacket(MemoryStream dataStream, int senderId)
-    {
-        var guidBytes = new byte[16];
-        try
-        {
-            dataStream.ReadExactly(guidBytes);
-        }
-        catch (EndOfStreamException)
-        {
-            Logger.Warn($"Error parsing Guid packet body, packet too short. Packet body length: {dataStream.Length}");
-            return;
-        }
-        var guid = new Guid(guidBytes);
-        var data = new byte[dataStream.Length - dataStream.Position];
-        dataStream.ReadExactly(data);
-        HandleDataPacket(guid, data, senderId);
-    }
-
-    private static void ServerHandleStaticPacket(MemoryStream dataStream, int senderId)
-    {
-        using var br = GetBinaryReader(dataStream);
-        var networkId = 0;
-        try
-        {
-            networkId = br.ReadInt32();
-        }
-        catch (EndOfStreamException)
-        {
-            Logger.Warn($"Error parsing Static packet body, packet too short. Packet body length: {dataStream.Length}");
-            return;
-        }
-        var data = new byte[dataStream.Length - dataStream.Position];
-        dataStream.ReadExactly(data);
-        HandleStaticDataPacket(networkId, data, senderId);
-    }
-
-    private static void ServerHandlePacket(Packet packet, int peerId, byte channelId)
-    {
-        var bytes = new byte[packet.Length];
-        packet.CopyTo(bytes);
-
-        using var ms = new MemoryStream(bytes);
-        var (rebroadcastPeers, packetIsForServer) = TryGetTargetPeers(ms);
-        if (rebroadcastPeers is null)
-        {
-            Logger.Warn($"Packet of length: {packet.Length} failed to parse");
-            return;
-        }
-
-        var sendingPeer = connectedPeers.GetValueOrDefault((uint)peerId);
-        var isBroadcast = rebroadcastPeers.Count == 0 && !packetIsForServer;
-        packetIsForServer = packetIsForServer || isBroadcast;
-
-        var data = new byte[packet.Length - ms.Position];
-        ms.ReadExactly(data);
-        var rebroadcastData = CreateRebroadcastData(data, peerId);
-        var rebroadcastPacket = default(Packet);
-        var reliability = (PacketReliability)(channelId % 3);
-        var flags = ReliabilityToPacketFlags(reliability);
-        rebroadcastPacket.Create(rebroadcastData, flags);
-
-        if (isBroadcast)
-        {
-            host!.Broadcast(channelId, ref rebroadcastPacket, excludedPeer: sendingPeer);
-        }
-        else if (rebroadcastPeers.Count > 0)
-        {
-            host!.Broadcast(channelId, ref rebroadcastPacket, rebroadcastPeers.ToArray());
-        }
-
-        if (packetIsForServer)
-        {
-            using var dataStream = new MemoryStream(data);
-            var idType = (IdTypes)dataStream.ReadByte();
-            switch (idType)
-            {
-                case IdTypes.Guid:
-                    ServerHandleGuidPacket(dataStream, peerId);
-                    break;
-                case IdTypes.Static:
-                    ServerHandleStaticPacket(dataStream, peerId);
-                    break;
-                default:
-                    Logger.Warn("Unexpected id type in packet body");
-                    break;
-            }
         }
     }
 
@@ -671,38 +555,6 @@ public static class NetworkManager
         }
     }
 
-    // Notify newly connected peer of their remote peer id
-    // Notify other peers of newly connected peer
-    // Notify newly connected peer of all other peers
-    private static void NotifyPeersOfConnection(Peer peer)
-    {
-        var peerId = peer.ID + 1;
-        var connectionEstablishedData = new byte[2];
-        connectionEstablishedData[0] = (byte)PacketTypes.ConnectionEstablished;
-        connectionEstablishedData[1] = (byte)peerId;
-        var connectionEstablishedPacket = default(Packet);
-        connectionEstablishedPacket.Create(connectionEstablishedData, PacketFlags.Reliable);
-
-        var connectionData = new byte[2];
-        connectionData[0] = (byte)PacketTypes.Connect;
-        connectionData[1] = (byte)peerId;
-        var connectionDataPacket = default(Packet);
-        connectionDataPacket.Create(connectionData, PacketFlags.Reliable);
-
-        host!.Broadcast(1, ref connectionDataPacket, peer);
-        peer.Send(1, ref connectionEstablishedPacket);
-
-        foreach (var peerKey in connectedPeers.Keys)
-        {
-            var existingPeerData = new byte[2];
-            existingPeerData[0] = (byte)PacketTypes.Connect;
-            existingPeerData[1] = (byte)peerKey;
-            var existingPeerPacket = default(Packet);
-            existingPeerPacket.Create(existingPeerData, PacketFlags.Reliable);
-            peer.Send(1, ref existingPeerPacket);
-        }
-    }
-
     private static void NotifyPeersOfDisconnection(Peer peer)
     {
         var peerId = peer.ID + 1;
@@ -713,48 +565,6 @@ public static class NetworkManager
         disconnectPacket.Create(disconnectData, PacketFlags.Reliable);
 
         host!.Broadcast(1, ref disconnectPacket);
-    }
-
-    private static void ServerTick()
-    {
-        for (var result = host!.Service(0, out var netEvent); result > 0; result = host.CheckEvents(out netEvent))
-        {
-            var peerId = netEvent.Peer.ID + 1;
-            switch (netEvent.Type)
-            {
-                case EventType.Connect:
-                    {
-                        NotifyPeersOfConnection(netEvent.Peer);
-                        connectedPeers.Add(peerId, netEvent.Peer);
-                        PeerConnected?.Invoke((int)peerId);
-                        Logger.Debug($"Peer connected with ID: {peerId}");
-                        break;
-                    }
-                case EventType.Disconnect:
-                    {
-                        connectedPeers.Remove(peerId);
-                        NotifyPeersOfDisconnection(netEvent.Peer);
-                        PeerDisconnected?.Invoke((int)peerId);
-                        Logger.Debug($"Peer disconnected with ID: {peerId}");
-                        break;
-                    }
-                case EventType.Receive:
-                    {
-                        using var packet = netEvent.Packet;
-                        ServerHandlePacket(packet, (int)peerId, netEvent.ChannelID);
-                        break;
-                    }
-                case EventType.Timeout:
-                    {
-                        connectedPeers.Remove(peerId);
-                        Logger.Debug($"Peer timed out with ID: {peerId}");
-                        NotifyPeersOfDisconnection(netEvent.Peer);
-                        PeerDisconnected?.Invoke((int)peerId);
-                        break;
-                    }
-                    
-            }
-        }
     }
 
     private static void ClientTick()

--- a/Engine/AM2E/Networking/NetworkManager.cs
+++ b/Engine/AM2E/Networking/NetworkManager.cs
@@ -8,7 +8,7 @@ public static class NetworkManager
 {
     private static bool isNetworking;
 
-    private static bool isConnected;
+    internal static bool isConnected;
 
     private static bool isServer;
 
@@ -36,7 +36,7 @@ public static class NetworkManager
         }
     }
 
-    public static int RemotePeerId { get; private set; } = -1;
+    public static int RemotePeerId { get; internal set; } = -1;
 
     public static event Action<int>? PeerConnected;
     
@@ -87,6 +87,11 @@ public static class NetworkManager
     internal static void OnPeerDisconnected(int peerId)
     {
         PeerDisconnected?.Invoke(peerId);
+    }
+
+    internal static void OnConnectedToServer(int remotePeerId)
+    {
+        ConnectedToServer?.Invoke(remotePeerId);
     }
 
     public static void StartServer(int port, int maxClients = DEFAULT_MAX_CLIENTS)
@@ -214,7 +219,7 @@ public static class NetworkManager
         }
         else
         {
-            ClientTick();
+            Client.ClientTick(host!);
         }
     }
 
@@ -436,125 +441,6 @@ public static class NetworkManager
         }
     }
 
-    private static void ParseDataPacket(MemoryStream packetStream, int senderId)
-    {
-        var guidBytes = new byte[16];
-        try
-        {
-            packetStream.ReadExactly(guidBytes);
-        }
-        catch (Exception ex)
-        {
-            Logger.Warn($"Error when reading data packet:\n{ex}");
-            return;
-        }
-
-        var guid = new Guid(guidBytes);
-        var data = new byte[packetStream.Length - packetStream.Position];
-        packetStream.ReadExactly(data);
-        HandleDataPacket(guid, data, senderId);
-    }
-
-    private static void ParseStaticDataPacket(MemoryStream packetStream, int senderId)
-    {
-        if (packetStream.Length - packetStream.Position < 4)
-        {
-            Logger.Warn($"Error when reading data packet: Packet is not long enough!");
-            return;
-        }
-        using var br = GetBinaryReader(packetStream);
-
-        var networkId = br.ReadInt32();
-        var data = new byte[packetStream.Length - packetStream.Position];
-        packetStream.ReadExactly(data);
-        HandleStaticDataPacket(networkId, data, senderId);
-    }
-
-    private static void ClientHandlePacket(Packet packet)
-    {
-        if (packet.Length == 0)
-        {
-            Logger.Warn("Received malformed packet");
-            return;
-        }
-
-        var bytes = new byte[packet.Length];
-        packet.CopyTo(bytes);
-
-        using var ms = new MemoryStream(bytes);
-        var packetType = (PacketTypes)ms.ReadByte();
-
-        switch (packetType)
-        {
-            case PacketTypes.Data:
-                {
-                    var senderId = ms.ReadByte();
-                    if (senderId == -1)
-                    {
-                        Logger.Warn($"Error: Malformed data packet");
-                    }
-
-                    var idType = (IdTypes)ms.ReadByte();
-                    switch (idType)
-                    {
-                        case IdTypes.Guid:
-                            ParseDataPacket(ms, senderId);
-                            break;
-                        case IdTypes.Static:
-                            ParseStaticDataPacket(ms, senderId);
-                            break;
-                        default:
-                            Logger.Warn($"Unexpected id type in packet body");
-                            break;
-                    }
-                    break;
-                }
-            case PacketTypes.Disconnect:
-                {
-                    var disconnectedPeerId = ms.ReadByte();
-                    if (disconnectedPeerId == -1)
-                    {
-                        Logger.Warn("Error: Malformed disconnect packet");
-                        return;
-                    }
-                    Logger.Debug($"Client disconnected with ID: {disconnectedPeerId}");
-                    PeerDisconnected?.Invoke(disconnectedPeerId);
-                    break;
-                }
-            case PacketTypes.Connect:
-                {
-                    var connectedPeerId = ms.ReadByte();
-                    if (connectedPeerId == -1)
-                    {
-                        Logger.Warn($"Error: Malformed connect packet");
-                        return;
-                    }
-                    PeerConnected?.Invoke(connectedPeerId);
-                    Logger.Debug($"Client connected with ID: {connectedPeerId}");
-                    break;
-                }
-            case PacketTypes.ConnectionEstablished:
-                {
-                    var remotePeerId = ms.ReadByte();
-                    if (remotePeerId == -1)
-                    {
-                        Logger.Warn($"Error: Malformed connection established packt");
-                        return;
-                    }
-                    Logger.Debug($"Finished connecting to server, remote peer id: {remotePeerId}");
-                    isConnected = true;
-                    RemotePeerId = remotePeerId;
-                    ConnectedToServer?.Invoke(remotePeerId);
-                    break;
-                }
-            default:
-                {
-                    Logger.Warn($"Received unrecognised packet type");
-                    break;
-                }
-        }
-    }
-
     private static void NotifyPeersOfDisconnection(Peer peer)
     {
         var peerId = peer.ID + 1;
@@ -565,35 +451,5 @@ public static class NetworkManager
         disconnectPacket.Create(disconnectData, PacketFlags.Reliable);
 
         host!.Broadcast(1, ref disconnectPacket);
-    }
-
-    private static void ClientTick()
-    {
-        for (var result = host!.Service(0, out var netEvent); result > 0; result = host.CheckEvents(out netEvent))
-        {
-            switch (netEvent.Type)
-            {
-                case EventType.Connect:
-                    connectedPeers.Add(netEvent.Peer.ID, netEvent.Peer);
-                    Logger.Debug($"Server acknowledged connection, waiting for full connection to be established");
-                    break;
-                case EventType.Disconnect:
-                    connectedPeers.Remove(netEvent.Peer.ID);
-                    Logger.Debug("Server disconnected");
-                    StopClient();
-                    return;
-                case EventType.Receive:
-                    {
-                        using var packet = netEvent.Packet;
-                        ClientHandlePacket(packet);
-                        break;
-                    }
-                case EventType.Timeout:
-                    connectedPeers.Remove(netEvent.Peer.ID);
-                    Logger.Debug("Server timed out");
-                    StopClient();
-                    return;
-            }
-        }	
     }
 }

--- a/Engine/AM2E/Networking/NetworkManager.cs
+++ b/Engine/AM2E/Networking/NetworkManager.cs
@@ -112,8 +112,9 @@ public static class NetworkManager
         Logger.Debug("Stopped server");
     }
 
-    public static void StartClient(string ip, int port)
+    public static void StartClient(string ip, int port, Action<bool>? finishedAction = null)
     {
+        finishedAction ??= (_) => {};
         try
         {
             if (!isNetworking)
@@ -131,6 +132,7 @@ public static class NetworkManager
             host.Create();
 
             host.Connect(address, NUM_CHANNELS * 3);
+            Client.finishedAction = finishedAction;
             Logger.Debug("Started client");
         }
         catch (Exception)

--- a/Engine/AM2E/Networking/PacketReliability.cs
+++ b/Engine/AM2E/Networking/PacketReliability.cs
@@ -1,0 +1,9 @@
+namespace AM2E.Networking;
+
+public enum PacketReliability
+{
+    Reliable = 0,
+    UnreliableOrdered = 1,
+    Unreliable = 2
+}
+

--- a/Engine/AM2E/Networking/Server.cs
+++ b/Engine/AM2E/Networking/Server.cs
@@ -1,5 +1,6 @@
 using ENet;
 using static AM2E.Networking.NetworkManager;
+using static AM2E.Networking.NetworkHelpers;
 
 namespace AM2E.Networking;
 
@@ -13,70 +14,67 @@ internal static class Server
     private static void NotifyPeersOfConnection(Host host, Peer peer)
     {
         var peerId = peer.ID + 1;
+        var defaultReliableChannel = GetENetChannelId(PacketReliability.Reliable, 0);
         var connectionEstablishedData = new byte[2];
         connectionEstablishedData[0] = (byte)PacketTypes.ConnectionEstablished;
         connectionEstablishedData[1] = (byte)peerId;
-        var connectionEstablishedPacket = default(Packet);
-        connectionEstablishedPacket.Create(connectionEstablishedData, PacketFlags.Reliable);
+        var connectionEstablishedPacket = CreateENetPacket(connectionEstablishedData, PacketReliability.Reliable);
 
         var connectionData = new byte[2];
         connectionData[0] = (byte)PacketTypes.Connect;
         connectionData[1] = (byte)peerId;
-        var connectionDataPacket = default(Packet);
-        connectionDataPacket.Create(connectionData, PacketFlags.Reliable);
+        var connectionDataPacket = CreateENetPacket(connectionData, PacketReliability.Reliable);
 
-        host.Broadcast(1, ref connectionDataPacket, peer);
-        peer.Send(1, ref connectionEstablishedPacket);
+        host.Broadcast(defaultReliableChannel, ref connectionDataPacket, peer);
+        peer.Send(defaultReliableChannel, ref connectionEstablishedPacket);
 
         foreach (var peerKey in connectedPeers.Keys)
         {
             var existingPeerData = new byte[2];
             existingPeerData[0] = (byte)PacketTypes.Connect;
             existingPeerData[1] = (byte)peerKey;
-            var existingPeerPacket = default(Packet);
-            existingPeerPacket.Create(existingPeerData, PacketFlags.Reliable);
-            peer.Send(1, ref existingPeerPacket);
+            var existingPeerPacket = CreateENetPacket(existingPeerData, PacketReliability.Reliable);
+            peer.Send(defaultReliableChannel, ref existingPeerPacket);
         }
-    }
-
-    private static void NotifyPeersOfDisconnection(Host host, Peer peer)
-    {
-        var peerId = peer.ID + 1;
-        var disconnectData = new byte[2];
-        disconnectData[0] = (byte)PacketTypes.Disconnect;
-        disconnectData[1] = (byte)peerId;
-        var disconnectPacket = default(Packet);
-        disconnectPacket.Create(disconnectData, PacketFlags.Reliable);
-
-        host.Broadcast(1, ref disconnectPacket);
     }
 
     private static (List<Peer>?, bool) TryGetTargetPeers(Stream packetStream)
     {
-        try
+        var peerCount = packetStream.ReadByte();
+
+        if (peerCount == -1)
         {
-            var peerCount = packetStream.ReadByte();
-            var packetIsForServer = false;
-            var peers = new List<Peer>();
-            for (var i = 0; i < peerCount; i++)
-            {
-                var peer = packetStream.ReadByte();
-                if (peer == ServerPeerId)
-                {
-                    packetIsForServer = true;
-                }
-                else
-                {
-                    peers.Add(connectedPeers.GetValueOrDefault((uint)peer));
-                }
-            }
-            return (peers, packetIsForServer);
-        }
-        catch (Exception ex)
-        {
-            Logger.Warn($"Error when parsing packet header:\n{ex}");
+            Logger.Warn("Hit end of stream when parsing packet header peer count");
             return (null, false);
         }
+
+        var peerBytes = new byte[peerCount];
+
+        for (var i = 0; i < peerCount; i++)
+        {
+            var num = packetStream.ReadByte();
+            if (num == -1)
+            {
+                Logger.Warn("Hit end of stream when parsing packet header peer count");
+                return (null, false);
+            }
+            peerBytes[i] = (byte)num;
+        }
+
+        var packetIsForServer = false;
+        var peers = new List<Peer>();
+        foreach (var peer in peerBytes)
+        {
+            if (peer == ServerPeerId)
+            {
+                packetIsForServer = true;
+            }
+            else
+            {
+                peers.Add(connectedPeers.GetValueOrDefault(peer));
+            }
+        }
+        return (peers, packetIsForServer);
     }
 
     private static byte[] CreateRebroadcastData(byte[] data, int peerId)
@@ -145,10 +143,8 @@ internal static class Server
         var data = new byte[packet.Length - ms.Position];
         ms.ReadExactly(data);
         var rebroadcastData = CreateRebroadcastData(data, peerId);
-        var rebroadcastPacket = default(Packet);
         var reliability = (PacketReliability)(channelId % 3);
-        var flags = ReliabilityToPacketFlags(reliability);
-        rebroadcastPacket.Create(rebroadcastData, flags);
+        var rebroadcastPacket = CreateENetPacket(rebroadcastData, reliability);
 
         if (isBroadcast)
         {
@@ -178,6 +174,15 @@ internal static class Server
         }
     }
 
+    internal static void KickPeer(int peerId)
+    {
+        if (connectedPeers.TryGetValue((uint)peerId, out var peer))
+        {
+            peer.DisconnectNow(0);
+            DisconnectPeer((uint)peerId);
+        }
+    }
+
     internal static void ServerTick(Host host)
     {
         for (var result = host.Service(0, out var netEvent); result > 0; result = host.CheckEvents(out netEvent))
@@ -195,9 +200,7 @@ internal static class Server
                     }
                 case EventType.Disconnect:
                     {
-                        connectedPeers.Remove(peerId);
-                        NotifyPeersOfDisconnection(host, netEvent.Peer);
-                        OnPeerDisconnected((int)peerId);
+                        DisconnectPeer(peerId);
                         Logger.Debug($"Peer disconnected with ID: {peerId}");
                         break;
                     }
@@ -209,10 +212,8 @@ internal static class Server
                     }
                 case EventType.Timeout:
                     {
-                        connectedPeers.Remove(peerId);
+                        DisconnectPeer(peerId);
                         Logger.Debug($"Peer timed out with ID: {peerId}");
-                        NotifyPeersOfDisconnection(host, netEvent.Peer);
-                        OnPeerDisconnected((int)peerId);
                         break;
                     }
                     

--- a/Engine/AM2E/Networking/Server.cs
+++ b/Engine/AM2E/Networking/Server.cs
@@ -1,0 +1,222 @@
+using ENet;
+using static AM2E.Networking.NetworkManager;
+
+namespace AM2E.Networking;
+
+internal static class Server
+{
+    const byte ServerPeerId = 0;
+
+    // Notify newly connected peer of their remote peer id
+    // Notify other peers of newly connected peer
+    // Notify newly connected peer of all other peers
+    private static void NotifyPeersOfConnection(Host host, Peer peer)
+    {
+        var peerId = peer.ID + 1;
+        var connectionEstablishedData = new byte[2];
+        connectionEstablishedData[0] = (byte)PacketTypes.ConnectionEstablished;
+        connectionEstablishedData[1] = (byte)peerId;
+        var connectionEstablishedPacket = default(Packet);
+        connectionEstablishedPacket.Create(connectionEstablishedData, PacketFlags.Reliable);
+
+        var connectionData = new byte[2];
+        connectionData[0] = (byte)PacketTypes.Connect;
+        connectionData[1] = (byte)peerId;
+        var connectionDataPacket = default(Packet);
+        connectionDataPacket.Create(connectionData, PacketFlags.Reliable);
+
+        host.Broadcast(1, ref connectionDataPacket, peer);
+        peer.Send(1, ref connectionEstablishedPacket);
+
+        foreach (var peerKey in connectedPeers.Keys)
+        {
+            var existingPeerData = new byte[2];
+            existingPeerData[0] = (byte)PacketTypes.Connect;
+            existingPeerData[1] = (byte)peerKey;
+            var existingPeerPacket = default(Packet);
+            existingPeerPacket.Create(existingPeerData, PacketFlags.Reliable);
+            peer.Send(1, ref existingPeerPacket);
+        }
+    }
+
+    private static void NotifyPeersOfDisconnection(Host host, Peer peer)
+    {
+        var peerId = peer.ID + 1;
+        var disconnectData = new byte[2];
+        disconnectData[0] = (byte)PacketTypes.Disconnect;
+        disconnectData[1] = (byte)peerId;
+        var disconnectPacket = default(Packet);
+        disconnectPacket.Create(disconnectData, PacketFlags.Reliable);
+
+        host.Broadcast(1, ref disconnectPacket);
+    }
+
+    private static (List<Peer>?, bool) TryGetTargetPeers(Stream packetStream)
+    {
+        try
+        {
+            var peerCount = packetStream.ReadByte();
+            var packetIsForServer = false;
+            var peers = new List<Peer>();
+            for (var i = 0; i < peerCount; i++)
+            {
+                var peer = packetStream.ReadByte();
+                if (peer == ServerPeerId)
+                {
+                    packetIsForServer = true;
+                }
+                else
+                {
+                    peers.Add(connectedPeers.GetValueOrDefault((uint)peer));
+                }
+            }
+            return (peers, packetIsForServer);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Error when parsing packet header:\n{ex}");
+            return (null, false);
+        }
+    }
+
+    private static byte[] CreateRebroadcastData(byte[] data, int peerId)
+    {
+        using var ms = new MemoryStream();
+        ms.WriteByte((byte)PacketTypes.Data);
+        ms.WriteByte((byte)peerId);
+        ms.Write(data);
+
+        return ms.ToArray();
+    }
+
+    private static void ServerHandleGuidPacket(MemoryStream dataStream, int senderId)
+    {
+        var guidBytes = new byte[16];
+        try
+        {
+            dataStream.ReadExactly(guidBytes);
+        }
+        catch (EndOfStreamException)
+        {
+            Logger.Warn($"Error parsing Guid packet body, packet too short. Packet body length: {dataStream.Length}");
+            return;
+        }
+        var guid = new Guid(guidBytes);
+        var data = new byte[dataStream.Length - dataStream.Position];
+        dataStream.ReadExactly(data);
+        HandleDataPacket(guid, data, senderId);
+    }
+
+    private static void ServerHandleStaticPacket(MemoryStream dataStream, int senderId)
+    {
+        using var br = GetBinaryReader(dataStream);
+        var networkId = 0;
+        try
+        {
+            networkId = br.ReadInt32();
+        }
+        catch (EndOfStreamException)
+        {
+            Logger.Warn($"Error parsing Static packet body, packet too short. Packet body length: {dataStream.Length}");
+            return;
+        }
+        var data = new byte[dataStream.Length - dataStream.Position];
+        dataStream.ReadExactly(data);
+        HandleStaticDataPacket(networkId, data, senderId);
+    }
+
+    private static void ServerHandlePacket(Host host, Packet packet, int peerId, byte channelId)
+    {
+        var bytes = new byte[packet.Length];
+        packet.CopyTo(bytes);
+
+        using var ms = new MemoryStream(bytes);
+        var (rebroadcastPeers, packetIsForServer) = TryGetTargetPeers(ms);
+        if (rebroadcastPeers is null)
+        {
+            Logger.Warn($"Packet of length: {packet.Length} failed to parse");
+            return;
+        }
+
+        var sendingPeer = connectedPeers.GetValueOrDefault((uint)peerId);
+        var isBroadcast = rebroadcastPeers.Count == 0 && !packetIsForServer;
+        packetIsForServer = packetIsForServer || isBroadcast;
+
+        var data = new byte[packet.Length - ms.Position];
+        ms.ReadExactly(data);
+        var rebroadcastData = CreateRebroadcastData(data, peerId);
+        var rebroadcastPacket = default(Packet);
+        var reliability = (PacketReliability)(channelId % 3);
+        var flags = ReliabilityToPacketFlags(reliability);
+        rebroadcastPacket.Create(rebroadcastData, flags);
+
+        if (isBroadcast)
+        {
+            host.Broadcast(channelId, ref rebroadcastPacket, excludedPeer: sendingPeer);
+        }
+        else if (rebroadcastPeers.Count > 0)
+        {
+            host.Broadcast(channelId, ref rebroadcastPacket, [.. rebroadcastPeers]);
+        }
+
+        if (packetIsForServer)
+        {
+            using var dataStream = new MemoryStream(data);
+            var idType = (IdTypes)dataStream.ReadByte();
+            switch (idType)
+            {
+                case IdTypes.Guid:
+                    ServerHandleGuidPacket(dataStream, peerId);
+                    break;
+                case IdTypes.Static:
+                    ServerHandleStaticPacket(dataStream, peerId);
+                    break;
+                default:
+                    Logger.Warn("Unexpected id type in packet body");
+                    break;
+            }
+        }
+    }
+
+    internal static void ServerTick(Host host)
+    {
+        for (var result = host.Service(0, out var netEvent); result > 0; result = host.CheckEvents(out netEvent))
+        {
+            var peerId = netEvent.Peer.ID + 1;
+            switch (netEvent.Type)
+            {
+                case EventType.Connect:
+                    {
+                        NotifyPeersOfConnection(host, netEvent.Peer);
+                        connectedPeers.Add(peerId, netEvent.Peer);
+                        OnPeerConnected((int)peerId);
+                        Logger.Debug($"Peer connected with ID: {peerId}");
+                        break;
+                    }
+                case EventType.Disconnect:
+                    {
+                        connectedPeers.Remove(peerId);
+                        NotifyPeersOfDisconnection(host, netEvent.Peer);
+                        OnPeerDisconnected((int)peerId);
+                        Logger.Debug($"Peer disconnected with ID: {peerId}");
+                        break;
+                    }
+                case EventType.Receive:
+                    {
+                        using var packet = netEvent.Packet;
+                        ServerHandlePacket(host, packet, (int)peerId, netEvent.ChannelID);
+                        break;
+                    }
+                case EventType.Timeout:
+                    {
+                        connectedPeers.Remove(peerId);
+                        Logger.Debug($"Peer timed out with ID: {peerId}");
+                        NotifyPeersOfDisconnection(host, netEvent.Peer);
+                        OnPeerDisconnected((int)peerId);
+                        break;
+                    }
+                    
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Moved around multiplayer code so it's not in one big file anymore
- Refactored some common patterns into helper functions to make things easier to verify and read
- Added a finishedAction callback to StartClient so that you can more easily run code on connection/connection failure